### PR TITLE
Synch one-versus-all input with URL

### DIFF
--- a/server.R
+++ b/server.R
@@ -175,6 +175,7 @@ output$brain3d_all <- renderWebGL({
 query_neuron <- reactive({
   query_neuron <- input$query_all
   if(query_neuron == "") return("")
+  if(!fc_gene_name(query_neuron) %in% names(dps)) stop("Invalid neuron name! Valid names include fru-M-200266, Gad1-F-400113, Trh-M-400076, VGlut-F-800287, etc.")
   query_neuron
 })
 

--- a/server.R
+++ b/server.R
@@ -8,6 +8,9 @@ library(shinysky)
 library(ggplot2)
 library(downloader)
 
+# URL synching
+url_fields_to_sync <- c("query_all")
+
 # Load dps object for plotting neurons
 dps <- read.neuronlistfh(file.path(getOption('flycircuit.datadir'), 'dpscanon_f9dc90ce5b2ffb74af37db1e3a2cb35b.rds'))
 
@@ -104,6 +107,29 @@ link_for_neuron_type <- function(type) {
 
 shinyServer(function(input, output, session) {
 
+################
+# URL synching #
+################
+firstTime <- TRUE
+output$hash <- reactiveText(function() {
+  newHash <- paste(collapse=",", Map(function(field) {
+                    paste(sep="=", field, input[[field]])
+                  },
+                  url_fields_to_sync))
+  return(
+    if (!firstTime) {
+      newHash
+    } else {
+      if (is.null(input$hash)) {
+        NULL
+      } else {
+        firstTime <<- FALSE;
+        isolate(input$hash)
+      }
+    }
+  )
+})
+  
 #######################
 # Pairwise comparison #
 #######################

--- a/ui.R
+++ b/ui.R
@@ -7,6 +7,12 @@ library(shinyRGL)
 library(shinysky)
 library(ggplot2)
 
+# URL synching
+hashProxy <- function(inputoutputID) {
+  div(id=inputoutputID,class=inputoutputID,tag("div",""));
+}
+
+
 dps <- read.neuronlistfh(file.path(getOption('flycircuit.datadir'), 'dpscanon_f9dc90ce5b2ffb74af37db1e3a2cb35b.rds'))
 
 neuron_names <- fc_neuron(names(dps))
@@ -19,17 +25,16 @@ shinyUI(navbarPage("NBLAST on-the-fly",
   tabPanel("One against all",
     sidebarLayout(  
       sidebarPanel(
+        ################
+        # URL synching #
+        ################
+        includeHTML("URL.js"),
+        hashProxy("hash"),
+        
         h3("Instructions"),
         HTML("Select a FlyCircuit neuron to compare against all FlyCircuit neurons, with NBLAST. If the checkbox below is ticked, both forwards and reverse scores will be calculated, normalised and averaged, rather than just using the forwards score. The query neuron will be <b><span style='color: black;'>plotted in black</span></b> in the 3D viewer to the right, alongside the top 10 hits (rainbow coloured from <span style='color: red;'>red = best</span> to <span style='color: #FF0099;'>pink = worst</span>)."),
         h3("Query:"),
-        textInput.typeahead(
-          id="query_all",
-          placeholder="Type a FlyCircuit neuron name",
-          local=data.frame(name=neuron_names, id=neuron_ids),
-          valueKey = "name",
-          tokens=neuron_ids,
-          template = HTML("<p class='repo-language'>{{id}}</p> <p class='repo-name'>{{name}}</p>")
-        ),
+        textInput("query_all", "", ""),
         br(),
         br(),
         checkboxInput('use_mean', label="Use mean scores", value=FALSE),

--- a/url.js
+++ b/url.js
@@ -1,0 +1,73 @@
+<script type="text/javascript">
+(function(){
+ 
+  this.countValue=0;
+  
+  var changeInputsFromHash = function(newHash) {
+    // get hash OUTPUT
+    var hashVal = $(newHash).data().shinyInputBinding.getValue($(newHash))
+    if (hashVal == "") return
+    // get values encoded in hash
+    var keyVals = hashVal.substring(1).split(",").map(function(x){return x.split("=")})
+    // find input bindings corresponding to them
+    keyVals.map(function(x) {
+      var el=$("#"+x[0])
+      
+      if (el.length > 0 && el.val() != x[1]) {
+      
+        console.log("Attempting to update input " + x[0] + " with value " + x[1]);
+        if (el.attr("type") == "checkbox") {
+            el.prop('checked',x[1]=="TRUE")
+            el.change()
+        } else if(el.attr("type") == "radio") {
+          console.log("I don't know how to update radios")
+        } else if(el.attr("type") == "slider") {
+          // This case should be setValue but it's not implemented in shiny
+          el.slider("value",x[1])
+          //el.change()
+        } else { 
+            el.data().shinyInputBinding.setValue(el[0],x[1])
+            el.change()
+        }
+      }
+    })
+  }
+  
+  var HashOutputBinding = new Shiny.OutputBinding();
+  $.extend(HashOutputBinding, {
+    find: function(scope) {
+      return $(scope).find(".hash");
+    },
+    renderError: function(el,error) {
+      console.log("Shiny app failed to calculate new hash");
+    },
+    renderValue: function(el,data) {
+      console.log("Updated hash");
+      document.location.hash=data;
+      changeInputsFromHash(el);
+    }
+  });
+  Shiny.outputBindings.register(HashOutputBinding);
+  
+  var HashInputBinding = new Shiny.InputBinding();
+  $.extend(HashInputBinding, {
+    find: function(scope) {
+      return $(scope).find(".hash");
+    },
+    getValue: function(el) {
+      return document.location.hash;
+    },
+    subscribe: function(el, callback) {
+      window.addEventListener("hashchange",
+        function(e) {
+          changeInputsFromHash(el);
+          callback();
+        }
+        , false);
+    }
+  });
+  Shiny.inputBindings.register(HashInputBinding);
+ 
+  
+})()
+</script>


### PR DESCRIPTION
This allows us to have links to specific inputs (see #20 and #52), at the expense of the autocomplete (although the different autocomplete library used in 8d6d9c72a33af9dd4d0af517789873ecdb6d5622 might re-enable this, if the issues with incorrect Shiny-read values can be solved). The URL displayed in the browser is automatically updated when an input is submitted.